### PR TITLE
Add Element text processor command

### DIFF
--- a/WorldModel/WorldModel/Core/CoreOutput.aslx
+++ b/WorldModel/WorldModel/Core/CoreOutput.aslx
@@ -146,6 +146,7 @@
     data = NewDictionary()
     dictionary add (data, "fulltext", text)
     text = ProcessTextSection(text, data)
+    text = Replace(text, "@@@lt@@@", Chr(60))
     return (Replace(Replace(text, "@@@open@@@", "{"), "@@@close@@@", "}"))
   </function>
   
@@ -767,6 +768,16 @@
           return (ProcessTextSection(ListItem(elementslist, index), data))
         }
       }
+    }
+  ]]></function>
+  
+  <function name="ProcessTextCommand_Element" parameters="section, data"><![CDATA[
+    if (IsRegexMatch(":?/?\\w+\\b((?<=\\s)\\w+\\b|(?<=\\s)\\w+=\\w+\\b|(?<=\\s)\\w+=\"[^\"]*\"|(?<=\\s)\\w+='[^']*')*/?\\s*", section)) {
+      if (StartsWith (section, ":")) section = LTrim (Mid (section, 2))
+      game.textprocessorcommandresult = "<" + section + ">"
+    }
+    else {
+      game.textprocessorcommandresult = "@@@open@@@" + ProcessTextSection (section, data) + "@@@close@@@"
     }
   ]]></function>
   

--- a/WorldModel/WorldModel/Core/CoreTypes.aslx
+++ b/WorldModel/WorldModel/Core/CoreTypes.aslx
@@ -194,6 +194,12 @@
       <item key="=">
         game.textprocessorcommandresult = ProcessTextCommand_Eval (section, data)
       </item>
+      <item key=":">
+        game.textprocessorcommandresult = ProcessTextCommand_Element (section, data)
+      </item>
+      <item key="/">
+        game.textprocessorcommandresult = ProcessTextCommand_Element (section, data)
+      </item>
     </textprocessorcommands>
     <feature_devmode type="boolean">false</feature_devmode>
   </type>


### PR DESCRIPTION
https://textadventures.co.uk/forum/quest/topic/ykouw7idaeytupcl3rmywa/isnt-there-an-easy-way-to-add-text-processor-commands#b6d3a7cd-a2a8-42c6-a9b7-d74a76d40f62

> You can do `{:span id="spoooon"}spoon?{/span}` or whatever if you're getting frustrated with the online editor :)

---
Also added `@@@lt@@@` to be replaced with `<`, like `@@@open@@@` is replaced with `{`.