### PR TITLE
Fix issue with GetListDisplayAlias

### DIFF
--- a/WorldModel/WorldModel/Core/CoreDescriptions.aslx
+++ b/WorldModel/WorldModel/Core/CoreDescriptions.aslx
@@ -369,8 +369,7 @@
   <function name="GetListDisplayAlias" type="string" parameters="obj">
     <![CDATA[
     if (HasString(obj, "listalias")) {
-      // Modified by KV
-      result = ProcessText(obj.listalias)
+      result = obj.listalias
     }
     else {
       result = GetDisplayAlias(obj)


### PR DESCRIPTION
I modified GetListDisplayAlias to use the text processor if an object's listalias attribute was defined as a string.

Using an image like {img:foo.png} will cause errors when clicking the verb buttons in the pane.

Closes #1259