### PR TITLE
multiple commands and textprocessor_element fix

### DIFF
--- a/WorldModel/WorldModel/Core/CoreOutput.aslx
+++ b/WorldModel/WorldModel/Core/CoreOutput.aslx
@@ -771,13 +771,13 @@
     }
   ]]></function>
   
-  <function name="ProcessTextCommand_Element" parameters="section, data"><![CDATA[
+  <function name="ProcessTextCommand_Element" parameters="section, data" type="string"><![CDATA[
     if (IsRegexMatch(":?/?\\w+\\b((?<=\\s)\\w+\\b|(?<=\\s)\\w+=\\w+\\b|(?<=\\s)\\w+=\"[^\"]*\"|(?<=\\s)\\w+='[^']*')*/?\\s*", section)) {
       if (StartsWith (section, ":")) section = LTrim (Mid (section, 2))
-      game.textprocessorcommandresult = "<" + section + ">"
+      return("<" + section + ">")
     }
     else {
-      game.textprocessorcommandresult = "@@@open@@@" + ProcessTextSection (section, data) + "@@@close@@@"
+      return ("@@@open@@@" + ProcessTextSection (section, data) + "@@@close@@@")
     }
   ]]></function>
   

--- a/WorldModel/WorldModel/Core/CoreParser.aslx
+++ b/WorldModel/WorldModel/Core/CoreParser.aslx
@@ -71,17 +71,20 @@
           msg ("")
         }
         game.pov.commandmetadata = metadata
-        if (game.multiplecommands){		
+        if (game.multiplecommands) {
+          foreach (alias, metadata) {
+            command = Replace (command, alias, Replace (alias, ".", "@@@DOT@@@"))
+          }
           commands = Split(command, ".")
           if (ListCount(commands) = 1) {
             game.pov.commandqueue = null
-            HandleSingleCommand (Trim(command))
+            HandleSingleCommand (Trim(Replace(command, "@@@DOT@@@", ".")))
           }
           else {
             game.pov.commandqueue = commands
             HandleNextCommandQueueItem
           }
-		    }
+        }
         else {
           game.pov.commandqueue = null
           HandleSingleCommand (Trim(command))	


### PR DESCRIPTION
Handle alias including a `.` when `game.multiplecommands` is `true`

Fix error in ProcessTextCommand_Element