### PR TITLE
Fix AGAIN command

### DIFF
--- a/WorldModel/WorldModel/Core/CoreParser.aslx
+++ b/WorldModel/WorldModel/Core/CoreParser.aslx
@@ -138,7 +138,7 @@
       msg(Template("Noted"))
       FinishTurn
     }
-    else if (LCase(command) = "[Again1]" or LCase(command) = "[Again2]") {
+    else if (LCase(command) = LCase(Template("Again1")) or LCase(command) = LCase(Template(Again2"))) {
       // First handle AGAIN
       if (not game.pov.currentcommand = null) {
         HandleSingleCommand(game.pov.currentcommand)


### PR DESCRIPTION
Closes #1284

Some of the templates are not all lower-case. This will make both the command and the value of the template(s) lower-case before comparing them.