### PR TITLE
jugador => player

### DIFF
--- a/WorldModel/WorldModel/Core/Templates/Espanol.template
+++ b/WorldModel/WorldModel/Core/Templates/Espanol.template
@@ -9,11 +9,11 @@
     <firstpublished>$YEAR$</firstpublished>
   </game>
 
-  <object name="lugar">
+  <object name="room">
     <inherit name="editor_room" />
     <isroom />
 
-    <object name="jugador">
+    <object name="player">
       <inherit name="editor_object" />
       <inherit name="editor_player" />
     </object>


### PR DESCRIPTION
Also lugar => room

All the other templates use `room` and `player` for these objects' names, and Quest will create the `player` object and set it as `game.pov` when `game.pov` is not defined and `player` does not exist at that point in the `StartGame` script in **Core.aslx** (which is before `game.start` or any objects' `initilialise` scripts are called).